### PR TITLE
fix: incorrect content-type used in the example

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ async function main() {
 
   const { txSkeleton, outputIndex } = await createSpore({
     data: {
-      contentType: 'image/jpg',
+      contentType: 'image/jpeg',
       content: await fetchLocalFile('./image.jpg'),
     },
     toLock: wallet.lock,


### PR DESCRIPTION
We're using `image/jpg` as the content-type for `.jpg` images, which is wrong. 
The file extensions `.jpg` and `.jpeg` should both use `image/jpeg` as the `content-type`. 

Ref: https://stackoverflow.com/questions/33692835/is-the-mime-type-image-jpg-the-same-as-image-jpeg